### PR TITLE
Remove test calling a typehinted method with invalid type argument

### DIFF
--- a/tests/SwaggerAssert/ContainerTest.php
+++ b/tests/SwaggerAssert/ContainerTest.php
@@ -49,14 +49,4 @@ class ContainerTest extends TestBase
     {
         $this->assertInstanceOf('SwaggerAssert\Container\Actual', $subject->sample);
     }
-
-    /**
-     * @test
-     * @expectedException \Exception
-     */
-    public function setWithInvalidValue()
-    {
-        $subject = new Container();
-        $subject->push('sample', ['something array']);
-    }
 }


### PR DESCRIPTION
This test does not verify application code, instead test if PHP internal error system works.

Also Exception is not thrown by the Application, it's thrown by PHPUnit when intercept PHP Error