### PR TITLE
Add link to Maks3w/SwaggerAssertions for 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Swagger-assert
-enable to assert swagger doc keys and API response.
+enable to assert swagger 1.2 doc keys and API response. For Swagger 2 take a look to [SwaggerAssertions](https://github.com/Maks3w/SwaggerAssertions)
 
 [![Build Status](https://travis-ci.org/gong023/swagger-assert.svg)](https://travis-ci.org/gong023/swagger-assert)
 [![Coverage Status](https://coveralls.io/repos/gong023/swagger-assert/badge.png?branch=master)](https://coveralls.io/r/gong023/swagger-assert?branch=master)


### PR DESCRIPTION
Add link to https://github.com/Maks3w/SwaggerAssertions for Swagger 2 support
